### PR TITLE
Fix typos and formatting problems.

### DIFF
--- a/lib/wed/action.js
+++ b/lib/wed/action.js
@@ -115,12 +115,10 @@ Action.prototype.terminalEventHandler = function (e) {
     return false;
 };
 
-
-
 /**
  * Gets a description for this action.
  *
- * @returns {string} A description for the action
+ * @returns {string} A description for the action.
  */
 Action.prototype.getDescription = function () {
     return this._desc;
@@ -139,9 +137,9 @@ Action.prototype.getDescriptionFor = function (data) {
 };
 
 /**
- * Gets the abbreviated  description for this action.
+ * Gets the abbreviated description for this action.
  *
- * @returns {string} An abbreviated description
+ * @returns {string} An abbreviated description.
  */
 Action.prototype.getAbbreviatedDescription = function () {
     return this._abbreviated_desc;
@@ -176,7 +174,6 @@ Action.prototype.getLabelFor = function (data) {
 
     return desc;
 };
-
 
 /**
  * Converts this action to a string. By default calls {@link

--- a/lib/wed/decorator.js
+++ b/lib/wed/decorator.js
@@ -55,7 +55,7 @@ Decorator.prototype.addHandlers = function () {
  * Start listening to changes to the DOM tree.
  *
  * @param {jQuery} $root The DOM root that this decorator listens
- * to. This must be the same root as the root that the this
+ * to. This must be the same root as the root that this
  * decorator's domlistener listens on and the same root as the root
  * which the GUI updater updates.
  */
@@ -165,7 +165,7 @@ function tryToSetDataCaret(editor, data_caret) {
 }
 
 /**
- * Add a start label at the start of an element and end label at the
+ * Add a start label at the start of an element and an end label at the
  * end.
  *
  * @param {Node} root The root of the decorated tree.

--- a/lib/wed/domlistener.js
+++ b/lib/wed/domlistener.js
@@ -40,22 +40,22 @@ define(/** @lends module:domlistener */ function (require, exports, module) {
  *
  * Consider the following HTML fragment:
  *
- *     &lt;ul>
- *      &lt;li>foo&lt;/li>
- *     &lt;/ul>
+ *     <ul>
+ *      <li>foo</li>
+ *     </ul>
  *
- * If the fragment is added to a ``&lt;div>`` element, an
- * ``included-element`` event will be generated for ``&lt;ul>`` and
- * ``&lt;li>`` but an ``added-element`` event will be generated only
- * for ``&lt;ul>``. A ``changed-children`` event will be generated for
- * the parent of ``&lt;ul>``.
+ * If the fragment is added to a ``<div>`` element, an
+ * ``included-element`` event will be generated for ``<ul>`` and
+ * ``<li>`` but an ``added-element`` event will be generated only
+ * for ``<ul>``. A ``changed-children`` event will be generated for
+ * the parent of ``<ul>``.
  *
  * If the fragment is removed, an ``excluding-element`` and
- * ``excluded-element`` event will be generated for ``&lt;ul>`` and
- * ``&lt;li>`` but a ``removing-element`` and ``remove-element`` event
- * will be generated only for ``&lt;ul>``. A ``children-changing`` and
+ * ``excluded-element`` event will be generated for ``<ul>`` and
+ * ``<li>`` but a ``removing-element`` and ``remove-element`` event
+ * will be generated only for ``<ul>``. A ``children-changing`` and
  * ``children-changed`` event will be generated for the parent of
- * ``&lt;ul>``.
+ * ``<ul>``.
  *
  * The signatures of the event handlers and details of each event are
  * as follows:
@@ -66,7 +66,7 @@ define(/** @lends module:domlistener */ function (require, exports, module) {
  *
  *   There is no reason to provide ``parent``, ``previous_sibling``,
  *   ``next_sibling`` for an ``added-element`` event but having the
- *   same signature for additions and removals allows to use the same
+ *   same signature for additions and removals allows use of the same
  *   function for both cases. The ``element`` parameter is a single
  *   element. The ``removing-element`` event is generated **before**
  *   the element is removed. The ``removed-element`` event is
@@ -75,7 +75,7 @@ define(/** @lends module:domlistener */ function (require, exports, module) {
  *   ``previous_sibling`` and ``next_sibling`` because the element is
  *   no longer in the tree.
  *
- * - ``included-element``, ``excluding-element``, `excluded-element``:
+ * - ``included-element``, ``excluding-element``, ``excluded-element``:
  *
  *   ``handler(root, tree, parent, previous_sibling, next_sibling,
  *   element)``
@@ -167,7 +167,7 @@ define(/** @lends module:domlistener */ function (require, exports, module) {
  *
  *   The ``-ed`` version of these events are still useful. For
  *   instance, a wed mode in use for editing scholarly articles
- *   listends for ``excluded-element`` with a selector that is a tag
+ *   listens for ``excluded-element`` with a selector that is a tag
  *   name so that it can remove references to these elements when they
  *   are removed. Since it does not need anything more complex then
  *   ``excluded-element`` works perfectly.

--- a/lib/wed/domutil.js
+++ b/lib/wed/domutil.js
@@ -999,7 +999,7 @@ function pointInContents(element, x, y) {
 }
 
 /**
- * Starting with the element passed, and walking up the elements's
+ * Starting with the element passed, and walking up the element's
  * parents, returns the first element that matches the selector.
  *
  * @param {Element} node The element to start with.
@@ -1123,14 +1123,13 @@ function childrenByClass(node, cl) {
     return ret;
 }
 
-
 /**
  * Find child matching the class.
  *
  * @param {Element} node The element whose child we are looking for.
  * @param {string} cl The class to use for matches.
  * @returns {Element|null} The first child (in document order) that
- * match the class, or ``null`` if nothing matches.
+ * matches the class, or ``null`` if nothing matches.
  */
 function childByClass(node, cl) {
     if (node === undefined || node === null ||
@@ -1148,7 +1147,7 @@ var textToHTML_span;
 /**
  * Convert a string to HTML encoding. For instance if you want to have
  * the less-than symbol be part of the contents of a ``span`` element,
- * it would have to be escaped to ``&lt;`` otherwise it would be
+ * it would have to be escaped to ``<`` otherwise it would be
  * interpreted as the beginning of a tag. This function does this kind
  * of escaping.
  *

--- a/lib/wed/files.js
+++ b/lib/wed/files.js
@@ -1,6 +1,6 @@
 /**
  * @module files
- * @desc A module to load and manage files stored in local forage.
+ * @desc A module to load and manage files stored in localForage.
  * @author Louis-Dominique Dubeau
  * @license MPL 2.0
  * @copyright 2014 Mangalam Research Center for Buddhist Languages
@@ -190,7 +190,6 @@ Files.prototype.onClear = log.wrap(function (ev) {
     });
 });
 
-
 Files.prototype.onNewFile = log.wrap(function (ev) {
     var me = this;
     bootbox.prompt("Give a name to your new file", function (name) {
@@ -219,7 +218,6 @@ Files.prototype._updateProgress = function () {
     var percent = this._progress_count / this._progress_total * 100;
     this._progress_bar.style.width = "" + percent + "%";
 };
-
 
 Files.prototype._stopProcessing = log.wrap(function () {
     this._$processing.modal('hide');

--- a/lib/wed/gui/action_context_menu.js
+++ b/lib/wed/gui/action_context_menu.js
@@ -45,17 +45,17 @@ var TYPE_FILTERS = TYPES.concat(undefined);
  * ``Transformation`` and then by the text associated with the
  * ``Transformation``. The kinds, in order, are:
  *
- * - other kinds than those listed below,
+ * - other kinds than those listed below
  *
- * - undefined ``kind``,
+ * - undefined ``kind``
  *
- * - ``"add"``,
+ * - ``"add"``
  *
- * - ``"delete"``,
+ * - ``"delete"``
  *
- * - ``"wrap"``,
+ * - ``"wrap"``
  *
- * - ``"unwrap"``,
+ * - ``"unwrap"``
  *
  * The text associated with the transformation is the text value of
  * the DOM ``Element`` object stored in the ``item`` field of the
@@ -72,7 +72,7 @@ var TYPE_FILTERS = TYPES.concat(undefined);
  * Typing text (e.g. "foo") will narrow the list of items to the text
  * that the user typed. Let's suppose that ``item`` is successively
  * taking the values in the ``items`` array. The filtering algorithm
- * first checks whether there is a ``item.data.name`` field. If there
+ * first checks whether there is an ``item.data.name`` field. If there
  * is, the match is performed against this field. If not, the match is
  * performed against the text of ``item.item``.
  *

--- a/lib/wed/gui/context_menu.js
+++ b/lib/wed/gui/context_menu.js
@@ -185,7 +185,6 @@ ContextMenu.prototype._render = function (items) {
     this._$menu.append(items);
 };
 
-
 /**
  * Dismisses the menu.
  */

--- a/lib/wed/gui/tooltip.js
+++ b/lib/wed/gui/tooltip.js
@@ -26,7 +26,7 @@ function _showHandler(ev) {
  * This function adds the ``wed-tooltip-for`` data to the tooltip
  * created for the ``$for`` element. This allows getting the DOM
  * element for which a tooltip was created from the DOM element
- * corresponding the tooltip itself.
+ * corresponding to the tooltip itself.
  *
  * This function also adds the ``wed-has-tooltip`` class to the
  * ``$for`` element. This allows knowing which elements from the GUI

--- a/lib/wed/gui/typeahead_popup.js
+++ b/lib/wed/gui/typeahead_popup.js
@@ -1,6 +1,6 @@
 /**
  * @module gui/typeahead_popup
- * @desc Support for a typeahead field that pop up in the editing pane.
+ * @desc Support for a typeahead field that pops up in the editing pane.
  * @author Louis-Dominique Dubeau
  * @license MPL 2.0
  * @copyright 2015 Mangalam Research Center for Buddhist Languages
@@ -38,7 +38,7 @@ require("typeahead");
  * may get overriden.
  * @param {string} placeholder The placeholder text to use.
  * @param {module:gui/typeahead_popup~TypeaheadPopupOptions} options
- * The options to pass to the unerlying Twitter Typeahead menu.
+ * The options to pass to the underlying Twitter Typeahead menu.
  * @param {Function} dismiss_callback Function to call when the popup
  * is dismissed.
  */

--- a/lib/wed/guiroot.js
+++ b/lib/wed/guiroot.js
@@ -24,7 +24,6 @@ AttributeNotFound.prototype.name = "AttributeNotFound";
 
 exports.AttributeNotFound = AttributeNotFound;
 
-
 /**
  * @classdesc This is a DLocRoot class customized for use to mark the
  * root of the GUI tree.
@@ -168,7 +167,6 @@ GUIRoot.prototype.pathToNode = function (path) {
 
     return parent;
 };
-
 
 exports.GUIRoot = GUIRoot;
 

--- a/lib/wed/input_trigger.js
+++ b/lib/wed/input_trigger.js
@@ -119,7 +119,7 @@ function InputTrigger(editor, selector) {
  * key to the same <code>InputTrigger</code> object, the
  * <code>InputTrigger</code> class does not define how one handler
  * could prevent another handler from executing. Calling the methods
- * on the <code>event</code> object does not in any way affect how a
+ * on the <code>event</code> object does not in any way affect how an
  * <code>InputTrigger</code> calls its handlers. However, as stated
  * above, these methods can prevent further propagation of the
  * JavaScript event. Consequently, if more than one handler should

--- a/lib/wed/jquery.findandself.js
+++ b/lib/wed/jquery.findandself.js
@@ -37,4 +37,4 @@
     };
 }));
 
-//  LocalWords:  Mangalam MPL Dubeau findandself jquery
+//  LocalWords: Mangalam MPL Dubeau findandself jquery

--- a/lib/wed/lib/simple_event_emitter.js
+++ b/lib/wed/lib/simple_event_emitter.js
@@ -61,7 +61,7 @@ SimpleEventEmitter.prototype.addEventListener = function (event_name,
  * Adds a one-time listener for an event. The listener will be called
  * only once. If this method is called more than once with the same
  * listener, the listener will be called for each call made to this
- * method. The order in which event listener are added matters. An
+ * method. The order in which event listeners are added matters. An
  * earlier event listener returning <code>false</code> will prevent
  * later listeners from being called.
  *

--- a/lib/wed/mode.js
+++ b/lib/wed/mode.js
@@ -128,7 +128,7 @@ Mode.prototype.getStylesheets = function () {
 /**
  * @param {Node} element This is the element to examine.
  * @returns {Array.<Node>} An array of two elements. The first is the
- * node before editable contents, the second the node after. Either
+ * node before editable contents, the second is the node after. Either
  * node can be null if there is nothing before or after editable
  * contents. Both are null if there is nothing around the editable
  * content.

--- a/lib/wed/mode_validator.js
+++ b/lib/wed/mode_validator.js
@@ -12,7 +12,7 @@ define(/** @lends module:mode_validator */ function (require, exports, module) {
  * @classdesc A mode validator performs mode-specific checks on a
  * document being edited with the mode. These checks should be those
  * that a schema cannot perform. We have split this functionality off
- * from the modes themselves because such validation may need to
+ * from the modes themselves because such validation may need to be
  * performed on "bare" documents, i.e. not being edited in wed but as
  * part of server-side processing. Modes require a full-fledged editor
  * to operate and thus would be rather heavy for the task of merely

--- a/lib/wed/modes/generic/generic.js
+++ b/lib/wed/modes/generic/generic.js
@@ -29,7 +29,7 @@ require("./generic_meta");
  *
  * Recognized options:
  *
- * - ``meta``: this option can be a a path (a string) pointing to a
+ * - ``meta``: this option can be a path (a string) pointing to a
  *   module that implements the meta object needed by the mode. Or it
  *   can be an object of the form:
  *

--- a/lib/wed/modes/generic/generic_meta.js
+++ b/lib/wed/modes/generic/generic_meta.js
@@ -23,7 +23,7 @@ var WED_MODES_GENERIC_META_READY =
  * @classdesc Meta-information for the generic mode. This is
  * information that cannot be simply derived from the schema.
  *
- * Object of this class take the following options:
+ * Objects of this class take the following options:
  *
  * + ``metadata``: a URL to a JSON file that contains metadata that
  * this meta should read.
@@ -52,7 +52,6 @@ function Meta (options) {
 Meta.prototype._ready = function () {
     pubsub.publish(WED_MODES_GENERIC_META_READY, this);
 };
-
 
 /**
  * Resolves the metadata option from a URL to actual data.

--- a/lib/wed/modes/generic/generic_tr.js
+++ b/lib/wed/modes/generic/generic_tr.js
@@ -237,7 +237,7 @@ function err_filter(err) {
  *
  * @param {Node} el The element that should be subject to the
  * autoinsertion algorithm.
- * @param {module:wed~Editor} editor The editor which own the element.
+ * @param {module:wed~Editor} editor The editor which owns the element.
  */
 function _autoinsert(el, editor) {
     while(true) {

--- a/lib/wed/onbeforeunload.js
+++ b/lib/wed/onbeforeunload.js
@@ -21,7 +21,7 @@ function default_check() {
 }
 
 /**
- * Installs a <code>onbeforeunload</code> handler.
+ * Installs an <code>onbeforeunload</code> handler.
  *
  * @param {Window} win The window to install it on.
  * @param {string} [message=undefined] The message to show to the

--- a/lib/wed/onerror.js
+++ b/lib/wed/onerror.js
@@ -34,8 +34,6 @@ aria-hidden="true">&times;</button>\
   </div>\
 </div>');
 
-
-
 // Normally onerror will be reset by reloading but when testing with
 // mocha we don't want reloading, so we export this function.
 function _reset() {

--- a/lib/wed/oop.js
+++ b/lib/wed/oop.js
@@ -29,7 +29,7 @@ function inherit(inheritor, inherited) {
  * Makes a class implement a mixin. This means that the prototype
  * fields of the mixin are copied into the class that implements
  * it. The mixin can either be a class (a function with a
- * <code>prototype</code> field) or an mapping of (key, value) pairs.
+ * <code>prototype</code> field) or a mapping of key-value pairs.
  *
  * @param {Function} mixes The class that implements the mixin.
  * @param {Function} mixin The mixin to implement.

--- a/lib/wed/refman.js
+++ b/lib/wed/refman.js
@@ -28,7 +28,7 @@ function ReferenceManager (name) {
 }
 
 /**
- * <p>Allocate a label for an id. The relation between id an label
+ * <p>Allocate a label for an id. The relation between id and label
  * remains constant until {@link
  * module:refman~ReferenceManager#deallocateAll deallocateAll} is
  * called.</p>
@@ -79,7 +79,6 @@ ReferenceManager.prototype.nextNumber = function () {
     return ++this._highest_number;
 };
 
-
 exports.ReferenceManager = ReferenceManager;
 
 var sense_labels = 'abcdefghijklmnopqrstuvwxyz';
@@ -112,7 +111,6 @@ SenseReferenceManager.prototype.allocateLabel = function (id) {
 SenseReferenceManager.prototype._deallocateAllLabels = function () {
     this._next_sense_label_ix = 0;
 };
-
 
 exports.___test_rm = new SenseReferenceManager();
 

--- a/lib/wed/transformation.js
+++ b/lib/wed/transformation.js
@@ -80,9 +80,9 @@ var TYPE_TO_NODE_TYPE = _.extend(Object.create(null), {
  * @param {string} desc The description of this transformation. A
  * transformation's {@link
  * module:transformation~Transformation#getDescriptionFor
- * getDescriptionFor} method will replace ``&lt;name>`` with the name
+ * getDescriptionFor} method will replace ``<name>`` with the name
  * of the node actually being processed. So a string like ``Remove
- * &lt;name>`` would become ``Remove foo`` when the transformation is
+ * <name>`` would become ``Remove foo`` when the transformation is
  * called for the element ``foo``.
  * @param {string} [abbreviated_desc] An abbreviated description of this
  * transformation.

--- a/lib/wed/tree_updater.js
+++ b/lib/wed/tree_updater.js
@@ -492,7 +492,7 @@ TreeUpdater.prototype.setTextNode = function (node, value) {
 
 /**
  * A primitive method. Sets a text node to a specified value. This
- * method must not be called directly by code that perform changes of
+ * method must not be called directly by code that performs changes of
  * the DOM tree at a high level, because it does not prevent a text
  * node from becoming empty. Call {@link
  * module:tree_updater~TreeUpdater#removeNode setTextNode}
@@ -665,7 +665,7 @@ TreeUpdater.prototype.mergeTextNodesNF = function (node) {
 
 /**
  * A primitive method. Removes a node from the DOM tree. This method
- * must not be called directly by code that perform changes of the DOM
+ * must not be called directly by code that performs changes of the DOM
  * tree at a high level, because it does not prevent two text nodes
  * from being contiguous after deletion of the node. Call {@link
  * module:tree_updater~TreeUpdater#removeNode removeNode}
@@ -767,7 +767,6 @@ TreeUpdater.prototype.setAttributeNS = function (node, ns, attribute, value) {
 
 };
 
-
 /**
  * Converts a node to a path.
  *
@@ -788,8 +787,6 @@ TreeUpdater.prototype.nodeToPath = function (node) {
 TreeUpdater.prototype.pathToNode = function (path) {
     return this._dloc_root.pathToNode(path);
 };
-
-
 
 exports.TreeUpdater = TreeUpdater;
 

--- a/lib/wed/undo.js
+++ b/lib/wed/undo.js
@@ -13,7 +13,7 @@ var oop = require("./oop");
 
 /**
  * @classdesc <p>An UndoList records operations that may be undone or redone. It
- * maintains a single list of {@link module:undo~Undo Undo} objects
+ * maintains a single list of {@link module:undo~Undo Undo} objects in
  * the order by which they are passed to the {@link
  * module:undo~UndoList#record record()} method.</p>
  *

--- a/lib/wed/updater_domlistener.js
+++ b/lib/wed/updater_domlistener.js
@@ -65,7 +65,6 @@ Listener.prototype.clearPending = function () {
     }
 };
 
-
 /**
  * Handles {@link module:tree_updater~TreeUpdater#event:insertNodeAt
  * insertNodeAt} events.
@@ -172,7 +171,7 @@ Listener.prototype._deleteNodeHandler = function (ev) {
  * @param {Array.<Node>} removed Removed children.
  * @param {Node|undefined} prev Node preceding the children.
  * @param {Node|undefined} next Node following the children.
- * @returns {Array.<Array>} An list of call signatures. Each signature
+ * @returns {Array.<Array>} A list of call signatures. Each signature
  * is a list which has a function for first element and the parameters
  * to pass to this function.
  */
@@ -232,7 +231,6 @@ Listener.prototype._setTextNodeValueHandler = function (ev) {
     this._scheduleProcessTriggers();
 };
 
-
 /**
  * Handles {@link module:tree_updater~TreeUpdater#event:setAttributeNS
  * setAttributeNS} events.
@@ -262,7 +260,6 @@ Listener.prototype._setAttributeNSHandler = function (ev) {
     this._scheduleProcessTriggers();
 };
 
-
 /**
  * Sets a timeout to run the triggers that must be run.
  * @private
@@ -286,7 +283,7 @@ Listener.prototype._scheduleProcessTriggers = function () {
  * @param {Node} node The node added or removed.
  * @param {Node} target The parent of this node.
  *
- * @returns {Array.<Array>} An list of call signatures. Each signature
+ * @returns {Array.<Array>} A list of call signatures. Each signature
  * is a list which has a function for first element and the parameters
  * to pass to this function.
  */
@@ -320,7 +317,7 @@ Listener.prototype._addRemCalls = function (name, node, target) {
  * which we must issue the events.
  * @param {Node} target The parent of this node.
  *
- * @returns {Array.<Array>} An list of call signatures. Each signature
+ * @returns {Array.<Array>} A list of call signatures. Each signature
  * is a list which has a function for first element and the parameters
  * to pass to this function.
  */

--- a/lib/wed/util.js
+++ b/lib/wed/util.js
@@ -253,7 +253,7 @@ function _exceptionStackTrace(err) {
  * in the compact notation is equivalent to ``<anyName/>`` in the
  * expanded notation. And ``foo:*`` is equivalent to ``<nsName
  * ns="uri_of_foo">`` where ``uri_of_foo`` is the URI that has been
- * assocated with ``foo`` in the compact schema. It would be nice is
+ * assocated with ``foo`` in the compact schema. It would be nice if
  * the function here could reuse this notation, but we
  * cannot. Consider the case where an Relax NG schema in the compact
  * notation wants to declare a name pattern which means "any name in


### PR DESCRIPTION
## In convert.js:
  * The private function ``ancestorNamespaceValue`` is undocumented.
  * The public function ``toHTMLTree`` is undocumented.

## In domlistener.js:
  * The ``addHandler`` method does not have a type documented for the
    ``selector`` parameter.

## In domutil.js:
  * The public function ``indexOf`` is undocumented.

## In domutil.js:
  * A property description of the ``beforeDeleteNode`` event is missing.
  * Property descriptions of the ``insertNodeAt`` event are missing.
  * A property description of the ``setAttributeNS`` event is missing.
  * Property descriptions of the ``setTextNodeValue`` event are missing.

## In modes/test/test_mode_validator.js:
  * The public function ``Validator`` is undocumented.
  * The public method ``validateDocument`` of the function ``Validator`` is
    undocumented.

## In tree_updater.js:
  * The property description for the event ``deleteNode`` is missing.
  * The property descriptions for the event ``insertNodeAt`` are missing.

## In serializer.js:
  * The function ``serialize`` is exported but does not appear in the API.

## In validator.js:
  * The description of the parameter ``root`` for the class ``Validator``
    is incomplete.
  * The description of the parameter ``attributes`` for the method
    ``possibleAt`` is missing.

## In dloc.js:
  * The function ``DLocRoot`` has a @classdesc tag but is missing a @class or
    or @constructor tag.
  * The methods ``nodeToPath`` and ``pathToNode`` of the class ``DLocRoot``
    were not exported. (See previous.)

## In guiroot.js:
  * The function ``GUIRoot`` has a @classdesc tag but is missing a @class or
    or @constructor tag.
  * The methods ``nodeToPath`` and ``pathToNode`` of the class ``GUIRoot``
    were not exported. (See previous.)

## In mode_validator.js:
  * The class ``ModeValidator`` has a @classdesc tag but is missing a @class or
    or @constructor tag.
  * The method ``validateDocument`` of the class ``ModeValidator``
    was not exported. (See previous.)

## In preferences.js:
  * The class ``Preferences`` has a @classdesc tag but is missing a @class or
    or @constructor tag.
  * The methods ``get`` and ``set`` of the class ``Preferences``
    were not exported. (See previous.)

The following appear twice in the index because they are either inherited events or extended classes. (I'm unsure if this matters, but it could be difficult to distinguish between two events or classes with the same name in the index):

Events:
  * disabled
  * enabled
  * beforeDeleteNode
  * changed
  * deleteNode
  * insertNodeAt
  * setAttributeNS
  * setTextNodeValue

Classes:
  * Mode
  * Listener
  * ContextMenu
